### PR TITLE
Trebuchet: always set initial wallpaper offsets

### DIFF
--- a/src/com/slim/slimlauncher/Workspace.java
+++ b/src/com/slim/slimlauncher/Workspace.java
@@ -1493,6 +1493,7 @@ public class Workspace extends SmoothPagedView
         // Don't use all the wallpaper for parallax until you have at least this many pages
         private final int MIN_PARALLAX_PAGE_SPAN = 3;
         int mNumScreens;
+        boolean mCompletedInitialOffset;
 
         public WallpaperOffsetInterpolator() {
             mChoreographer = Choreographer.getInstance();
@@ -1507,7 +1508,8 @@ public class Workspace extends SmoothPagedView
         private void updateOffset(boolean force) {
             if (mWaitingForUpdate || force) {
                 mWaitingForUpdate = false;
-                if (computeScrollOffset() && mWindowToken != null) {
+                if ((!mCompletedInitialOffset || computeScrollOffset()) && mWindowToken != null) {
+                    mCompletedInitialOffset = true;
                     try {
                         mWallpaperManager.setWallpaperOffsets(mWindowToken,
                                 mWallpaperOffset.getCurrX(), 0.5f);


### PR DESCRIPTION
After a fresh boot, computeScrollOffset() always returns false. So the
result was the offsets were never properly being set on a fresh boot and
they were only being applied on first drag of the home screen, which
finally triggered computeScrollOffset() to return true.

Change-Id: Iccaedd742bed861fca1f50dd54e2e4537fd4c9b0